### PR TITLE
fix(procyonidate): createGlobPatternsForDependencies function

### DIFF
--- a/apps/procyonidae/tailwind.config.js
+++ b/apps/procyonidae/tailwind.config.js
@@ -1,7 +1,12 @@
 const { join } = require('path');
+// const { createGlobPatternsForDependencies } = require('@nrwl/react/tailwind');
 
 module.exports = {
-  purge: [join(__dirname, 'src/**/*.{js,ts,jsx,tsx}')],
+  purge: [
+    join(__dirname, 'src/**/*.{js,ts,jsx,tsx}'),
+    // https://githubmemory.com/repo/nrwl/nx/issues/6369
+    // ...createGlobPatternsForDependencies(__dirname),
+  ],
   darkMode: false, // or 'media' or 'class'
   theme: {
     extend: {},


### PR DESCRIPTION
Fixed `createGlobPatternsForDependencies` function from @nrwl/react/tailwind does not work on Windows